### PR TITLE
Fix stock creation with default notes

### DIFF
--- a/FinanceTracker/FinanceTracker/server/storage.ts
+++ b/FinanceTracker/FinanceTracker/server/storage.ts
@@ -669,6 +669,7 @@ export class MemStorage implements IStorage {
     const id = this.currentStockId++;
     const stock: Stock = {
       ...insertStock,
+      notes: insertStock.notes ?? null,
       id,
       createdAt: new Date(),
       updatedAt: new Date()


### PR DESCRIPTION
## Summary
- ensure `createStock` in `server/storage.ts` sets `notes` to `null` when missing

## Testing
- `npm install`
- `npm run check` *(fails: cannot find type definitions and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68497b223c8083239d8a94ea800607a9