### PR TITLE
Add modern TypeScript target

### DIFF
--- a/FinanceTracker/FinanceTracker/tsconfig.json
+++ b/FinanceTracker/FinanceTracker/tsconfig.json
@@ -6,6 +6,7 @@
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
     "module": "ESNext",
+    "target": "ES2022",
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- set `target` to `ES2022` in `tsconfig.json`

## Testing
- `npm run check` *(fails: TS2322 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68497b23efac8323a26ff2b75a3458ba