### PR TITLE
Fix createAccount defaults

### DIFF
--- a/FinanceTracker/FinanceTracker/server/storage.ts
+++ b/FinanceTracker/FinanceTracker/server/storage.ts
@@ -413,7 +413,14 @@ export class MemStorage implements IStorage {
 
   async createAccount(insertAccount: InsertAccount): Promise<Account> {
     const id = this.currentAccountId++;
-    const account: Account = { ...insertAccount, id };
+    const account: Account = {
+      id,
+      name: insertAccount.name,
+      type: insertAccount.type,
+      balance: insertAccount.balance ?? "0",
+      color: insertAccount.color ?? "#2563EB",
+      isActive: insertAccount.isActive ?? true,
+    };
     this.accounts.set(id, account);
     return account;
   }


### PR DESCRIPTION
## Summary
- assign default values when creating an account in memory storage

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68497b2352c08323a1ec1cbd80f14965